### PR TITLE
[codex] Add PIER 39 live source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,197 +1,240 @@
-# 🦛 moodeng.py
+# moodeng
 
-Powerful CLI and Python library for monitoring YouTube live streams for 
-Moo Deng appearances using state-of-the-art computer vision. 
+`moodeng` is a CLI and Python package for monitoring live animal streams with
+YOLOv8-based detection.
 
-<img width="1048" alt="image" src="https://github.com/user-attachments/assets/1c946d3b-7955-4ae4-a158-9df329e702db">
+The current code supports two source types:
 
-## ✨ Features
+- direct media or stream URLs that OpenCV or `yt-dlp` can open
+- supported live pages that embed an `HDRelay` camera, including the PIER 39
+  sea lion page
 
-- 🔍 Real-time hippo detection using YOLOv8
-- 🇹🇭 Defaults to the latest live Moo Deng stream from Zoodio Thailand
-- 🌙 Probably works in both day and night conditions
-- 📱 Multiple alert types:
-  - Console logging (default)
-  - SMS notifications (via Twilio, could use more testing)
-  - Push notifications (via Pushbullet, could use more testing)
-  - Custom alerts 
+It can also do a second-stage reference-image match for cases where the base
+detector only knows a generic class. That is the current path for identifying a
+specific sea lion such as Chonkers on the PIER 39 feed.
 
-Check out notes below for more details and caveats.
+## What It Does
 
-## 🚀 Quick Start
+- detects an OpenImages class such as `hippopotamus` or `Sea lion`
+- reads live sources from YouTube-style pages, direct stream URLs, or supported
+  `HDRelay` pages
+- can restrict alerts to one specific animal by comparing detections against one
+  or more reference images
+- supports console, Twilio SMS, and Pushbullet alerts
 
-### Requirements
+## Current Limitations
 
-- Python 3.12 (required for PyTorch compatibility)
+- The underlying `yolov8x-oiv7.pt` model uses generic OpenImages labels.
+  `Sea lion` exists, but species-level labels such as `Steller sea lion` do not.
+- Individual-animal matching is heuristic. It depends heavily on camera angle,
+  lighting, occlusion, and the quality of the reference images.
+- This repository does not currently include a real automated test suite.
+  Validation is mostly compile checks and smoke tests.
+
+## Requirements
+
+- Python 3.12
 - macOS, Linux, or WSL
 
-### Installation
+## Installation
 
 ```bash
-# 1. Get Python 3.12 if needed
-brew install pyenv
-pyenv install 3.12
-pyenv global 3.12
-
-# 2. Clone and install
 git clone https://github.com/tnm/moodeng.git
 cd moodeng
 chmod +x install.sh
 ./install.sh
-
-# 3. Activate environment
 source .venv/bin/activate
 ```
 
-### Run
+## Basic Usage
 
-Start watching for hippos:
+If no URL is provided, the CLI tries to resolve the latest stream from
+`@ZoodioThailand`.
+
 ```bash
 moodeng
 ```
 
-That's it! First run will:
-1. Download the ML model
-2. Connect to Moo Deng's stream
-3. Start watching for hippos
+To watch a specific live page or stream:
 
-## 📓 Important Notes
-
-* The live stream from Moo Deng's YouTube channel is *usually* online, but it could be offline. If it's offline, you'll get an error, and can try again later.
-
-* The Moo Deng ML model detection is basic for now, so you may get alerts when Jonah (i.e., Moo Deng's mother) appears. She is noticeably larger than Moo Deng, as she is an adult. Sometimes the stream features only Jonah, sometimes it's both Jonah and Moo Deng. 
-
-* Potentially you might only see Moo Deng, but that is uncommon since she is a baby.
-
-* In any case, the model is not yet fine-tuned for Moo Deng, but pull requests are welcome and we can work together to improve it. Ideally, you could choose Jonah, Moo Deng, or both.
-
-* Detection numbers may be lower than expected, since the model is trained on the common hippo (*Hippopotamus amphibius*), and not Moo Deng's species—the pygmy hippo (*Choeropsis liberiensis*). This will improve. Given this, detection alerts are set relatively low: so don't worry, you should still get Moo Deng alerts.
-
-## 💫 More things you can do
-
-Explicitly specify a different stream in case the default one goes offline
-or you want to try with your own stream:
 ```bash
-moodeng --url "YOUR_YOUTUBE_URL"
+moodeng --url "YOUR_STREAM_OR_PAGE_URL"
 ```
 
-Get SMS notifications (requires Twilio account):
+## PIER 39
+
+The PIER 39 sea lion page is not a YouTube stream. It uses an `HDRelay` live
+camera embed. The current code resolves that page to the underlying live frame
+source automatically.
+
+Generic sea lion detection:
+
 ```bash
-moodeng --alert-type sms \
+moodeng \
+  --url "https://www.pier39.com/sealions/" \
+  --target-label "Sea lion"
+```
+
+Chonkers-only matching:
+
+```bash
+moodeng \
+  --url "https://www.pier39.com/sealions/" \
+  --target-label "Sea lion" \
+  --reference-name "Chonkers" \
+  --reference-image ./refs/chonkers-1.jpg \
+  --reference-image ./refs/chonkers-2.jpg
+```
+
+If matching is too loose or too strict, tune the threshold:
+
+```bash
+moodeng \
+  --url "https://www.pier39.com/sealions/" \
+  --target-label "Sea lion" \
+  --reference-name "Chonkers" \
+  --reference-image ./refs/chonkers-1.jpg \
+  --reference-threshold 0.12
+```
+
+The best reference images are cropped or nearly cropped views of the same
+animal from the same camera, with stable lighting and pose.
+
+## CLI Options
+
+Common options:
+
+- `--url`: live page or stream URL
+- `--target-label`: OpenImages class label to detect
+- `--min-confidence`: minimum YOLO confidence for a candidate detection
+- `--alert-cooldown`: minimum seconds between alerts
+- `--debug`: enable debug logging
+
+Reference matching:
+
+- `--reference-name`: friendly label for alerts
+- `--reference-image`: path to a reference image; repeat to add more images
+- `--reference-threshold`: minimum reference-match score required to alert
+
+Alerts:
+
+- `--alert-type log`
+- `--alert-type sms`
+- `--alert-type push`
+
+Twilio:
+
+- `--twilio-sid`
+- `--twilio-token`
+- `--twilio-from`
+- `--twilio-to`
+
+Pushbullet:
+
+- `--pushbullet-key`
+
+## Alert Examples
+
+SMS:
+
+```bash
+moodeng \
+  --url "https://www.pier39.com/sealions/" \
+  --target-label "Sea lion" \
+  --alert-type sms \
   --twilio-sid "YOUR_SID" \
   --twilio-token "YOUR_TOKEN" \
   --twilio-from "+1234567890" \
   --twilio-to "+1234567890"
 ```
 
-Get push notifications (requires Pushbullet account):
+Pushbullet:
+
 ```bash
-moodeng --alert-type push --pushbullet-key "YOUR_KEY"
+moodeng \
+  --url "https://www.pier39.com/sealions/" \
+  --target-label "Sea lion" \
+  --alert-type push \
+  --pushbullet-key "YOUR_KEY"
 ```
 
-## 🐍 Python Usage
+## Python Usage
 
-The CLI is cool, but you can also work with `moodeng` directly from Python. 
-You may want to integrate this library into another project, e.g, Enterprise SaaS app that monitors your 
-customers' streams for pygmy hippos, etc etc.
+The public Python entry point is `Monitor`.
+
+Basic example:
 
 ```python
-from moodeng import monitor, LogAlerter
+from moodeng import Monitor
 
-# Basic usage (defaults to Moo Deng's stream)
-m = monitor(alerter=LogAlerter())
-m.start()
-
-# Or customize everything
-m = monitor(
-    youtube_url="YOUR_YOUTUBE_URL",
-    min_confidence=0.7,
-    alert_cooldown=300 # seconds between alerts
+monitor = Monitor(
+    youtube_url="https://www.pier39.com/sealions/",
+    target_label="Sea lion",
+    min_confidence=0.2,
+    alert_cooldown=300,
 )
-m.start()
+monitor.start()
 ```
 
-### Different Alert Types
+Reference matching:
 
 ```python
-# SMS Alerts
-from moodeng import monitor, SMSAlerter
+from moodeng import Monitor
 
-m = monitor(
-    alerter=SMSAlerter(
-        account_sid="YOUR_SID",
-        auth_token="YOUR_TOKEN",
-        from_number="+1234567890",
-        to_number="+1234567890"
-    )
+monitor = Monitor(
+    youtube_url="https://www.pier39.com/sealions/",
+    target_label="Sea lion",
+    reference_name="Chonkers",
+    reference_images=[
+        "./refs/chonkers-1.jpg",
+        "./refs/chonkers-2.jpg",
+    ],
+    reference_match_threshold=0.12,
 )
-m.start()
-
-# Push Notifications
-from moodeng import monitor, PushAlerter
-
-m = monitor(
-    alerter=PushAlerter(api_key="YOUR_PUSHBULLET_KEY")
-)
-m.start()
+monitor.start()
 ```
 
-### Custom Alert Handler
+Custom alerts:
 
 ```python
-from moodeng import Alerter, monitor
+from moodeng import Alerter, Monitor
 
-class MyCustomAlerter(Alerter):
-    def send_alert(self, message: str):
-        # Do something with the alert
-        print(f"Custom alert: {message}")
 
-m = monitor(alerter=MyCustomAlerter())
-m.start()
+class MyAlerter(Alerter):
+    def send_alert(self, message: str) -> None:
+        print(message)
+
+
+monitor = Monitor(
+    alerter=MyAlerter(),
+    youtube_url="https://www.pier39.com/sealions/",
+    target_label="Sea lion",
+)
+monitor.start()
 ```
 
-## 🛠️ Advanced Usage from CLI
+## Development Notes
 
-### Debug Mode
-If something's not working:
-```bash
-moodeng --debug
-```
+- The package name is still `moodeng`, even though the current behavior is no
+  longer specific to Moo Deng.
+- Several user-facing strings in the code still use older hippo-oriented text.
+  The README now documents the behavior more accurately than the CLI output.
+- The repository currently depends on heavyweight vision packages and model
+  downloads, so startup can be slow on a fresh environment.
 
-### Detection Settings
-Adjust how sensitive the hippo detection is:
-```bash
-# More selective detection
-moodeng --min-confidence 0.8
+## Validation
 
-# Change how often you get alerts
-moodeng --alert-cooldown 600  # 10 minutes
-```
+Recent manual checks for the current branch:
 
-## 🤝 Contributing
+- `python3 -m compileall src/moodeng`
+- `git diff --check`
+- Pier 39 live-source smoke test:
+  resolved `https://www.pier39.com/sealions/` to camera `CID_UROS0000008D`
+  and fetched a live `6526x1576` frame through the `HDRelay` path
 
-Please do! Here's how:
+## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/AmazingFeature`)
-3. Make your changes
-4. Run tests (`pytest`)
-5. Commit (`git commit -m 'Add AmazingFeature'`)
-6. Push (`git push origin feature/AmazingFeature`)
-7. Open a Pull Request
-
-## 📄 License
-
-Distributed under the MIT License. See `LICENSE` for more information.
-
-## 🆘 Support
-
-Need help?
-1. Run with `--debug` for more information
-2. [Open an issue](https://github.com/tnm/moodeng/issues)
-3. Email ted@cased.com
-
-## 🔒 Security
-
-Found a security issue? I would be incredibly impressed, and will try to send you a
-hippo figurine as a thank you. Email me at ted@cased.com.
+1. Create a branch.
+2. Make the change.
+3. Run the relevant checks.
+4. Open a pull request.

--- a/src/moodeng/cli.py
+++ b/src/moodeng/cli.py
@@ -8,19 +8,33 @@ warnings.filterwarnings("ignore", category=SyntaxWarning)
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Monitor streams for pygmy hippos (หมูเด็ง)',
+        description='Monitor live streams for animal detections',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     
     # Basic configuration
     parser.add_argument('--url', 
-                       help='YouTube stream URL (defaults to Moo Deng stream)')
+                       help='Live page or stream URL (defaults to Moo Deng stream)')
     parser.add_argument('--config', 
                        help='Path to config file')
     parser.add_argument('--min-confidence', 
                        type=float,
                        default=0.20,
                        help='Minimum confidence threshold for detection')
+    parser.add_argument('--target-label',
+                       default=None,
+                       help='OpenImages class to detect (for example: hippopotamus, "Sea lion")')
+    parser.add_argument('--reference-name',
+                       default=None,
+                       help='Friendly name for reference-image matching, e.g. "Chonkers"')
+    parser.add_argument('--reference-image',
+                       action='append',
+                       default=None,
+                       help='Path to a reference image for the specific animal you want to match; repeat this flag to add more images')
+    parser.add_argument('--reference-threshold',
+                       type=float,
+                       default=None,
+                       help='Minimum reference match score for alerting when using --reference-image')
     parser.add_argument('--alert-cooldown', 
                        type=int,
                        default=300,
@@ -75,7 +89,7 @@ def main():
         print("   3. Check https://www.youtube.com/@ZoodioThailand/live")
         return 0
     
-    print(f"🎥 Found stream: {stream_url}")
+    print(f"🎥 Found source: {stream_url}")
     print("🦛 Welcome to moodeng! Setting things up...")
     
     try:
@@ -159,12 +173,20 @@ def main():
     
     # Create monitor with merged configuration
     monitor_config = {
-        'youtube_url': stream_url  # Use the URL we already found
+        'youtube_url': stream_url,  # Use the URL we already found
     }
     
     if config:
         monitor_config.update(config)
-    
+
+    if args.target_label is not None:
+        monitor_config['target_label'] = args.target_label
+    if args.reference_name is not None:
+        monitor_config['reference_name'] = args.reference_name
+    if args.reference_image is not None:
+        monitor_config['reference_images'] = args.reference_image
+    if args.reference_threshold is not None:
+        monitor_config['reference_match_threshold'] = args.reference_threshold
     if args.min_confidence is not None:
         monitor_config['min_confidence'] = args.min_confidence
     if args.alert_cooldown is not None:
@@ -177,14 +199,14 @@ def main():
         print("🐛 Debug mode enabled")
     
     # Create and start monitor
-    print("🔧 Setting up hippo detector...")
+    print("🔧 Setting up detector...")
     monitor = Monitor(
         alerter=alerter,
         **monitor_config
     )
     
     try:
-        print("👀 Watching for pygmy hippos (Press Ctrl+C to stop)...")
+        print("👀 Watching the configured live source (Press Ctrl+C to stop)...")
         monitor.start()
     except KeyboardInterrupt:
         print("\n👋 Stopping hippo monitor...")

--- a/src/moodeng/config.py
+++ b/src/moodeng/config.py
@@ -37,6 +37,10 @@ def get_latest_stream_url(channel_id: str = "ZoodioThailand") -> str:
 
 DEFAULT_CONFIG = {
     "youtube_url": None,
+    "target_label": "hippopotamus",
+    "reference_name": None,
+    "reference_images": None,
+    "reference_match_threshold": 0.08,
     "min_confidence": 0.10,
     "alert_cooldown": 300,
 }

--- a/src/moodeng/detector.py
+++ b/src/moodeng/detector.py
@@ -1,19 +1,188 @@
 import cv2
 import time
+import re
+import json
+from pathlib import Path
+from difflib import get_close_matches
 from datetime import datetime
 from typing import Optional
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 import yt_dlp
 import warnings
+import numpy as np
 from ultralytics import YOLO
 from .alerters import Alerter, LogAlerter
 from .config import get_config
-from .exceptions import ModelError
+from .exceptions import ConfigurationError, ModelError
 import sys
 import subprocess
 import os
 
 # Mute any CUDA warnings
 warnings.filterwarnings("ignore", category=FutureWarning)
+
+TARGET_LABEL_ALIASES = {
+    "stellar sea lion": "steller sea lion",
+    "stellar sea lions": "steller sea lion",
+    "steller sea lions": "steller sea lion",
+}
+
+HTTP_HEADERS = {
+    "User-Agent": "moodeng/0.1 (+https://github.com/tnm/moodeng)",
+}
+
+
+def _normalize_label(label: str) -> str:
+    """Normalize a class label for resilient matching."""
+    return re.sub(r"[^a-z0-9]+", " ", label.lower()).strip()
+
+
+def _label_candidates(label: str) -> list[str]:
+    """Build normalized label candidates, including common aliases."""
+    normalized = _normalize_label(label)
+    candidates = [normalized]
+
+    aliased = TARGET_LABEL_ALIASES.get(normalized)
+    if aliased:
+        candidates.append(aliased)
+
+    expanded = []
+    for candidate in candidates:
+        expanded.append(candidate)
+        if candidate.endswith("s"):
+            expanded.append(candidate[:-1])
+        else:
+            expanded.append(f"{candidate}s")
+
+    return list(dict.fromkeys(part for part in expanded if part))
+
+
+def _normalize_remote_url(url: str) -> str:
+    """Normalize scheme-relative URLs returned by remote player configs."""
+    if url.startswith("//"):
+        return f"https:{url}"
+    return url
+
+
+def _http_get_bytes(url: str) -> bytes:
+    """Fetch bytes from a remote URL with a stable user agent."""
+    request = Request(url, headers=HTTP_HEADERS)
+    with urlopen(request, timeout=30) as response:
+        return response.read()
+
+
+def _http_get_text(url: str) -> str:
+    """Fetch text content from a remote URL."""
+    return _http_get_bytes(url).decode("utf-8", errors="replace")
+
+
+def _http_get_json(url: str):
+    """Fetch JSON from a remote URL."""
+    return json.loads(_http_get_text(url))
+
+
+class ReferenceMatcher:
+    """Match detections against one or more reference images of a specific animal."""
+
+    def __init__(self, reference_paths: list[str]):
+        self.orb = cv2.ORB_create(nfeatures=1000)
+        self.matcher = cv2.BFMatcher(cv2.NORM_HAMMING)
+        self.references = []
+
+        for reference_path in reference_paths:
+            image = cv2.imread(reference_path)
+            if image is None:
+                raise ConfigurationError(f"Failed to load reference image: {reference_path}")
+
+            descriptors, keypoint_count = self._compute_descriptors(image)
+            if descriptors is None or keypoint_count == 0:
+                raise ConfigurationError(
+                    f"Reference image has no usable visual features: {reference_path}"
+                )
+
+            self.references.append({
+                "path": reference_path,
+                "descriptors": descriptors,
+                "keypoint_count": keypoint_count,
+            })
+
+        if not self.references:
+            raise ConfigurationError("At least one valid reference image is required")
+
+    def _compute_descriptors(self, image) -> tuple[Optional[cv2.typing.MatLike], int]:
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        height, width = gray.shape[:2]
+        longest_side = max(height, width)
+        if longest_side > 512:
+            scale = 512 / longest_side
+            gray = cv2.resize(gray, (int(width * scale), int(height * scale)))
+
+        keypoints, descriptors = self.orb.detectAndCompute(gray, None)
+        return descriptors, len(keypoints)
+
+    def score(self, image) -> float:
+        """Return the best normalized ORB match score across the references."""
+        descriptors, keypoint_count = self._compute_descriptors(image)
+        if descriptors is None or keypoint_count == 0:
+            return 0.0
+
+        best_score = 0.0
+        for reference in self.references:
+            raw_matches = self.matcher.knnMatch(reference["descriptors"], descriptors, k=2)
+            good_matches = []
+            for pair in raw_matches:
+                if len(pair) < 2:
+                    continue
+                first, second = pair
+                if first.distance < 0.75 * second.distance:
+                    good_matches.append(first)
+
+            denominator = max(1, min(reference["keypoint_count"], keypoint_count))
+            score = len(good_matches) / denominator
+            best_score = max(best_score, score)
+
+        return best_score
+
+
+class HDRelayLiveFrameSource:
+    """Poll live frames from an HDRelay camera using its public frame endpoints."""
+
+    def __init__(self, camera_id: str, host: str, position: str):
+        self.camera_id = camera_id
+        self.host = _normalize_remote_url(host).rstrip("/") + "/"
+        self.position = position
+        self.last_timestamp = None
+
+    def _info_url(self) -> str:
+        return (
+            f"{self.host}api/frames/info"
+            f"?camera={self.camera_id}&position={self.position}"
+        )
+
+    def _frame_url(self, timestamp: int) -> str:
+        return f"{self.host}frames/{self.camera_id}/{self.position}/{timestamp}"
+
+    def read(self):
+        """Return the newest available frame, or None if no new frame exists yet."""
+        info = _http_get_json(self._info_url())
+        latest_timestamp = int(info["last"])
+        if self.last_timestamp == latest_timestamp:
+            return None
+
+        frame_bytes = _http_get_bytes(self._frame_url(latest_timestamp))
+        frame = cv2.imdecode(np.frombuffer(frame_bytes, dtype=np.uint8), cv2.IMREAD_COLOR)
+        if frame is None:
+            raise RuntimeError(
+                f"Failed to decode HDRelay frame for {self.camera_id} at {latest_timestamp}"
+            )
+
+        self.last_timestamp = latest_timestamp
+        return frame
+
+    def release(self):
+        """Mirror the OpenCV VideoCapture interface."""
+        return None
 
 class Monitor:
     """
@@ -23,6 +192,10 @@ class Monitor:
         self,
         alerter: Optional[Alerter] = None,
         youtube_url: Optional[str] = None,
+        target_label: str = "hippopotamus",
+        reference_name: Optional[str] = None,
+        reference_images: Optional[list[str]] = None,
+        reference_match_threshold: float = 0.08,
         min_confidence: float = 0.10,
         alert_cooldown: int = 300
     ):
@@ -30,15 +203,20 @@ class Monitor:
         
         self.config = get_config({
             "youtube_url": youtube_url,
+            "target_label": target_label,
+            "reference_name": reference_name,
+            "reference_images": reference_images,
+            "reference_match_threshold": reference_match_threshold,
             "min_confidence": min_confidence,
             "alert_cooldown": alert_cooldown
         })
         
         if not self.config.get("youtube_url"):
-            raise ValueError("No YouTube URL provided! This shouldn't happen - please report this bug on GitHub.")
+            raise ValueError("No source URL provided! This shouldn't happen - please report this bug on GitHub.")
         
         self.alerter = alerter or LogAlerter()
         self.model = self._load_model()
+        self.reference_matcher = self._load_reference_matcher()
         self.last_alert_time = 0
         
     def _load_model(self):
@@ -48,23 +226,56 @@ class Monitor:
             print("🔄 Loading OpenImages model...")
             model = YOLO('yolov8x-oiv7.pt')  # OpenImages V7 model
             
-            print("\n🔍 Confirming that hippos are in the model...")
-            for class_id, name in model.names.items():
-                if 'hippopotamus' in name.lower():
-                    self.hippo_class = class_id
-                    break
-            if self.hippo_class is None:
-                raise ModelError("Couldn't find hippopotamus class in the model!")
+            requested_label = self.config["target_label"]
+            print(f"\n🔍 Confirming that {requested_label} is in the model...")
+            self.target_class, self.target_model_label = self._find_target_class(
+                model,
+                requested_label,
+            )
             
-            print(f"✨ Found hippo detection (class {self.hippo_class})")
+            print(f"✨ Found {self.target_model_label} detection (class {self.target_class})")
             return model
             
+        except ModelError:
+            raise
         except Exception as e:
             print(f"Failed to load OpenImages model: {e}")
-            raise ModelError("Couldn't find hippopotamus class in the model!")
+            raise ModelError(f"Couldn't find {self.config['target_label']} in the model!")
+
+    def _find_target_class(self, model, requested_label: str) -> tuple[int, str]:
+        """Resolve a requested class label against model class names."""
+        normalized_names = {
+            class_id: _normalize_label(name)
+            for class_id, name in model.names.items()
+        }
+        candidates = _label_candidates(requested_label)
+
+        for candidate in candidates:
+            for class_id, normalized_name in normalized_names.items():
+                if normalized_name == candidate:
+                    return class_id, model.names[class_id]
+
+        suggestions = get_close_matches(
+            candidates[0],
+            list(normalized_names.values()),
+            n=5,
+            cutoff=0.6,
+        )
+        suggestion_names = [
+            model.names[class_id]
+            for class_id, normalized_name in normalized_names.items()
+            if normalized_name in suggestions
+        ]
+        suggestion_text = ""
+        if suggestion_names:
+            suggestion_text = f" Close matches: {', '.join(suggestion_names)}."
+
+        raise ModelError(
+            f"Couldn't find a model class for '{requested_label}'.{suggestion_text}"
+        )
 
     def _get_stream_url(self, youtube_url: str) -> str:
-        """Get direct stream URL using yt-dlp"""
+        """Resolve a direct media URL from a supported page URL using yt-dlp."""
         ydl_opts = {
             'format': 'best',
             'quiet': True,
@@ -78,63 +289,206 @@ class Monitor:
                 print("💡 Tip: The stream might be offline. Try again later.")
                 raise RuntimeError(f"Failed to get stream URL: {str(e)}")
 
-    def start(self):
-        """Start monitoring the stream"""
-        print(f"\n📡 Connecting to stream: {self.config['youtube_url']}")
-        
+    def _resolve_hdrelay_page_source(self, page_url: str) -> dict:
+        """Resolve an HDRelay-backed page into a live frame polling source."""
+        page_html = _http_get_text(page_url)
+        match = re.search(r"HDRelay\.create\(\{[^}]*id:\s*['\"]([^'\"]+)['\"]", page_html)
+        if not match:
+            raise RuntimeError(f"Couldn't find an HDRelay camera on {page_url}")
+
+        camera_id = match.group(1)
+        player_config = _http_get_json(f"https://manage.hdrelay.com/player/{camera_id}")
+        camera_status = player_config.get("camera", {}).get("status", {})
+        if camera_status.get("online") is False:
+            raise RuntimeError(f"HDRelay camera {camera_id} is currently offline")
+
+        position = player_config.get("image", {}).get("position", "panorama")
+        host = player_config.get("host")
+        if not host:
+            raise RuntimeError(f"HDRelay player config for {camera_id} did not include a frame host")
+
+        return {
+            "kind": "hdrelay_frames",
+            "camera_id": camera_id,
+            "host": host,
+            "position": position,
+            "page_url": page_url,
+        }
+
+    def _resolve_source(self, source_url: str) -> dict:
+        """Resolve the configured source into either a video capture URL or a live frame source."""
+        parsed = urlparse(source_url)
+        if parsed.scheme in {"rtsp", "rtsps"}:
+            return {"kind": "video_capture", "capture_url": source_url}
+
+        lower_url = source_url.lower()
+        if lower_url.endswith((".m3u8", ".mp4", ".mjpeg", ".jpg", ".jpeg")):
+            return {"kind": "video_capture", "capture_url": source_url}
+
+        if "pier39.com/sealions" in lower_url or "hdrelay.com" in lower_url:
+            return self._resolve_hdrelay_page_source(source_url)
+
+        capture_url = self._get_stream_url(source_url)
+        return {"kind": "video_capture", "capture_url": capture_url}
+
+    def _load_reference_matcher(self) -> Optional[ReferenceMatcher]:
+        """Load reference images for individual-animal matching, if configured."""
+        reference_images = self.config.get("reference_images")
+        if not reference_images:
+            return None
+
+        normalized_paths = []
+        for reference_image in reference_images:
+            resolved = Path(reference_image).expanduser().resolve()
+            if not resolved.exists():
+                raise ConfigurationError(f"Reference image does not exist: {resolved}")
+            normalized_paths.append(str(resolved))
+
+        reference_name = self.config.get("reference_name") or "reference target"
+        print(f"🖼️ Loading {len(normalized_paths)} reference images for {reference_name}...")
+        matcher = ReferenceMatcher(normalized_paths)
+        print(
+            f"✨ Loaded reference matcher for {reference_name} "
+            f"(threshold {self.config['reference_match_threshold']:.2f})"
+        )
+        return matcher
+
+    def _crop_detection(self, frame, box) -> Optional[cv2.typing.MatLike]:
+        """Crop a detection box from the current frame."""
+        x1, y1, x2, y2 = [int(value) for value in box.xyxy[0].tolist()]
+        height, width = frame.shape[:2]
+        x1 = max(0, min(x1, width))
+        x2 = max(0, min(x2, width))
+        y1 = max(0, min(y1, height))
+        y2 = max(0, min(y2, height))
+        if x2 <= x1 or y2 <= y1:
+            return None
+        return frame[y1:y2, x1:x2]
+
+    def _process_frame(self, frame, check_count: int, target_label: str, subject_name: str):
+        """Run detection logic for a single frame."""
+        if check_count % 10 == 0:
+            print(f"\n🔍 Check #{check_count}. Looking for {subject_name}...")
+
+        current_time = time.time()
+        results = self.model(frame, verbose=False)
+
+        for result in results:
+            for box in result.boxes:
+                class_id = int(box.cls[0])
+                confidence = float(box.conf[0])
+                class_name = self.model.names[class_id]
+
+                match_score = None
+                is_reference_match = True
+                if class_id == self.target_class and confidence >= self.config["min_confidence"]:
+                    if self.reference_matcher:
+                        crop = self._crop_detection(frame, box)
+                        if crop is not None:
+                            match_score = self.reference_matcher.score(crop)
+                        else:
+                            match_score = 0.0
+                        is_reference_match = (
+                            match_score >= self.config["reference_match_threshold"]
+                        )
+
+                    if check_count % 4 == 0:
+                        if match_score is None:
+                            print(f"   🎯 Possible {target_label}! {confidence:.2%} confidence")
+                        else:
+                            print(
+                                f"   🎯 {target_label} detected "
+                                f"({confidence:.2%}, ref score {match_score:.2f})"
+                            )
+                elif "animal" in class_name.lower() and confidence > 0.6:
+                    if check_count % 10 == 0:
+                        print(f"   Found {class_name} with {confidence:.2%} confidence")
+
+                if (
+                    class_id == self.target_class
+                    and confidence >= self.config["min_confidence"]
+                    and is_reference_match
+                    and current_time - self.last_alert_time > self.config["alert_cooldown"]
+                ):
+                    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    if match_score is None:
+                        message = (
+                            f"🎯 {target_label} detected at {timestamp}! "
+                            f"(Confidence: {confidence:.2f})"
+                        )
+                    else:
+                        message = (
+                            f"🎯 {subject_name} matched at {timestamp}! "
+                            f"(Detection: {confidence:.2f}, Reference: {match_score:.2f})"
+                        )
+                    self.alerter.send_alert(message)
+                    self.last_alert_time = current_time
+
+    def _monitor_video_capture(self, stream_url: str, target_label: str, subject_name: str):
+        """Monitor a direct video stream via OpenCV."""
+        cap = cv2.VideoCapture(stream_url)
         try:
-            stream_url = self._get_stream_url(self.config['youtube_url'])
-            cap = cv2.VideoCapture(stream_url)
-            
-            print("👀 Connected! Watching for hippos on {self.config['youtube_url']}")
-            print("🦛 Note: model trained on common hippos, not pygmy hippos.)")
+            print(f"👀 Connected! Watching for {target_label} on {self.config['youtube_url']}")
+            if self.reference_matcher:
+                print(f"🧭 Reference matching is enabled for {subject_name}")
+
             check_count = 0
-            
             while True:
                 ret, frame = cap.read()
                 if not ret:
                     print("📺 Failed to grab frame, retrying...")
                     time.sleep(60)
                     continue
-                
+
                 check_count += 1
-                if check_count % 10 == 0:
-                    print(f"\n🔍 Check #{check_count}. Looking for hippos...")
-                
-                # Process detections
-                current_time = time.time()
-                results = self.model(frame, verbose=False)
-                
-                for result in results:
-                    for box in result.boxes:
-                        class_id = int(box.cls[0])
-                        confidence = float(box.conf[0])
-                        class_name = self.model.names[class_id]
-                        
-                        # Show any hippo detection above 10% confidence
-                        # and only show on every 10th check  
-                        if class_id == self.hippo_class and confidence > 0.10:
-                            if check_count % 4 == 0:
-                                print(f"   🦛 Possible hippo! {confidence:.2%} confidence")
-                        # Show other animals only if high confidence
-                        elif 'animal' in class_name.lower() and confidence > 0.6:
-                            if check_count % 10 == 0:
-                                print(f"   Found {class_name} with {confidence:.2%} confidence")
-                        
-                        # Alert on hippos with our configured confidence
-                        if (class_id == self.hippo_class 
-                            and confidence >= self.config["min_confidence"]
-                            and current_time - self.last_alert_time > self.config["alert_cooldown"]):
-                            
-                            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                            message = f"🦛 Hippo detected at {timestamp}! (Confidence: {confidence:.2f})"
-                            self.alerter.send_alert(message)
-                            self.last_alert_time = current_time
-                
+                self._process_frame(frame, check_count, target_label, subject_name)
                 time.sleep(1)
+        finally:
+            cap.release()
+
+    def _monitor_hdrelay_frames(self, source: dict, target_label: str, subject_name: str):
+        """Monitor an HDRelay page by polling for the latest live frame."""
+        frame_source = HDRelayLiveFrameSource(
+            camera_id=source["camera_id"],
+            host=source["host"],
+            position=source["position"],
+        )
+        print(
+            f"👀 Connected! Polling live frames for {target_label} from "
+            f"{source['page_url']} ({source['camera_id']})"
+        )
+        if self.reference_matcher:
+            print(f"🧭 Reference matching is enabled for {subject_name}")
+
+        check_count = 0
+        while True:
+            try:
+                frame = frame_source.read()
+            except Exception as e:
+                print(f"📺 Failed to fetch live HDRelay frame, retrying soon... ({e})")
+                time.sleep(5)
+                continue
+
+            if frame is None:
+                time.sleep(1)
+                continue
+
+            check_count += 1
+            self._process_frame(frame, check_count, target_label, subject_name)
+            time.sleep(0.2)
+
+    def start(self):
+        """Start monitoring the stream"""
+        print(f"\n📡 Connecting to stream: {self.config['youtube_url']}")
+        target_label = self.target_model_label.title()
+        subject_name = self.config.get("reference_name") or target_label
+
+        try:
+            source = self._resolve_source(self.config["youtube_url"])
+            if source["kind"] == "hdrelay_frames":
+                self._monitor_hdrelay_frames(source, target_label, subject_name)
+            else:
+                self._monitor_video_capture(source["capture_url"], target_label, subject_name)
                 
         except KeyboardInterrupt:
             print("\n👋 Stopping monitor...")
-        finally:
-            if 'cap' in locals():
-                cap.release()


### PR DESCRIPTION
## What changed

This PR updates `moodeng` from a YouTube-only Moo Deng monitor into a more general live-animal stream monitor with first-class support for the PIER 39 sea lion feed.

It includes:

- support for resolving the PIER 39 sea lion page to its underlying HDRelay live camera
- live frame polling for HDRelay-backed sources
- configurable target labels instead of a hard-wired `hippopotamus` class
- optional reference-image matching so a generic class like `Sea lion` can be narrowed to one specific animal such as Chonkers
- a full README rewrite to match the actual behavior of the code and remove the previous emoji-heavy marketing copy
- a CLI description update to reflect the broader scope of the tool

## Why

The old implementation assumed a YouTube-backed Moo Deng workflow and a single `hippopotamus` target class.

That broke down for the PIER 39 use case:

- the source is an HDRelay live page, not YouTube
- the base model only has the generic OpenImages class `Sea lion`
- identifying Chonkers requires a second-stage visual match against reference imagery rather than a species label

## User impact

Users can now run:

```bash
moodeng --url "https://www.pier39.com/sealions/" --target-label "Sea lion"
```

and can restrict alerts to a single animal with reference images:

```bash
moodeng \" 
--url
"https://www.pier39.com/sealions/"
\"
  --target-label "Sea lion" \" 
--reference-name
"Chonkers"
\"
  --reference-image ./refs/chonkers-1.jpg
```

## Validation

I ran the following checks locally:

- `python3 -m compileall src/moodeng`
- `git diff --check`
- `PYTHONPATH=src .venv/bin/python -m moodeng.cli --help`
- Pier 39 live-source smoke test:
  - resolved `https://www.pier39.com/sealions/` to camera `CID_UROS0000008D`
  - fetched a live `6526x1576` frame through the HDRelay path
- reference-image sanity check using the latest Downloads image as a Chonkers reference:
  - the model detected `Sea lion` in the reference image
  - the best self-match score was `0.55`
- short live Chonkers check against fresh Pier 39 frames:
  - no `Sea lion` detections were found in the sampled live frames, so there was no positive Chonkers match during that run

## Notes

This repository still does not have a real automated test suite, so validation is currently smoke-test level rather than unit/integration-test level.
