### PR TITLE
[codex] Clean up PIER 39 follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ specific sea lion such as Chonkers on the PIER 39 feed.
   `Sea lion` exists, but species-level labels such as `Steller sea lion` do not.
 - Individual-animal matching is heuristic. It depends heavily on camera angle,
   lighting, occlusion, and the quality of the reference images.
-- This repository does not currently include a real automated test suite.
-  Validation is mostly compile checks and smoke tests.
+- Automated coverage is still minimal. There are basic helper/config tests, but
+  validation is still mostly compile checks and smoke tests.
 
 ## Requirements
 
@@ -100,6 +100,9 @@ moodeng \
 The best reference images are cropped or nearly cropped views of the same
 animal from the same camera, with stable lighting and pose.
 
+The `./refs/chonkers-*.jpg` paths above are examples only. This repository does
+not ship Chonkers reference images.
+
 ## CLI Options
 
 Common options:
@@ -168,7 +171,7 @@ Basic example:
 from moodeng import Monitor
 
 monitor = Monitor(
-    youtube_url="https://www.pier39.com/sealions/",
+    source_url="https://www.pier39.com/sealions/",
     target_label="Sea lion",
     min_confidence=0.2,
     alert_cooldown=300,
@@ -182,7 +185,7 @@ Reference matching:
 from moodeng import Monitor
 
 monitor = Monitor(
-    youtube_url="https://www.pier39.com/sealions/",
+    source_url="https://www.pier39.com/sealions/",
     target_label="Sea lion",
     reference_name="Chonkers",
     reference_images=[
@@ -207,7 +210,7 @@ class MyAlerter(Alerter):
 
 monitor = Monitor(
     alerter=MyAlerter(),
-    youtube_url="https://www.pier39.com/sealions/",
+    source_url="https://www.pier39.com/sealions/",
     target_label="Sea lion",
 )
 monitor.start()
@@ -217,8 +220,6 @@ monitor.start()
 
 - The package name is still `moodeng`, even though the current behavior is no
   longer specific to Moo Deng.
-- Several user-facing strings in the code still use older hippo-oriented text.
-  The README now documents the behavior more accurately than the CLI output.
 - The repository currently depends on heavyweight vision packages and model
   downloads, so startup can be slow on a fresh environment.
 
@@ -227,6 +228,7 @@ monitor.start()
 Recent manual checks for the current branch:
 
 - `python3 -m compileall src/moodeng`
+- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests`
 - `git diff --check`
 - Pier 39 live-source smoke test:
   resolved `https://www.pier39.com/sealions/` to camera `CID_UROS0000008D`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "moodeng"
 version = "0.1.0"
-description = "🦛 Monitor for moo deng the hippo in her youtube stream"
+description = "Monitor live animal streams with YOLOv8-based detection"
 readme = "README.md"
 requires-python = ">=3.12,<3.13"
 authors = [

--- a/src/moodeng/__init__.py
+++ b/src/moodeng/__init__.py
@@ -1,5 +1,5 @@
 """
-Moodeng - Monitor for detecting pygmy hippos
+Moodeng - Monitor live streams for animal detections.
 """
 
 from .detector import Monitor

--- a/src/moodeng/alerters.py
+++ b/src/moodeng/alerters.py
@@ -34,4 +34,4 @@ class PushAlerter(Alerter):
         self.pb = Pushbullet(api_key)
 
     def send_alert(self, message: str) -> None:
-        self.pb.push_note("Moo Deng Alert! 🦛", message)
+        self.pb.push_note("moodeng alert", message)

--- a/src/moodeng/cli.py
+++ b/src/moodeng/cli.py
@@ -6,6 +6,7 @@ import warnings
 
 warnings.filterwarnings("ignore", category=SyntaxWarning)
 
+
 def main():
     parser = argparse.ArgumentParser(
         description='Monitor live streams for animal detections',
@@ -14,7 +15,7 @@ def main():
     
     # Basic configuration
     parser.add_argument('--url', 
-                       help='Live page or stream URL (defaults to Moo Deng stream)')
+                       help='Live page or stream URL (defaults to the latest configured stream)')
     parser.add_argument('--config', 
                        help='Path to config file')
     parser.add_argument('--min-confidence', 
@@ -90,7 +91,7 @@ def main():
         return 0
     
     print(f"🎥 Found source: {stream_url}")
-    print("🦛 Welcome to moodeng! Setting things up...")
+    print("Setting up moodeng...")
     
     try:
         print("🔍 Checking dependencies...")
@@ -117,7 +118,7 @@ def main():
                 "seaborn", "tqdm", "psutil", "scipy", "ultralytics",
                 "gitpython"
             ])
-            print("✨ Dependencies installed! Restarting moodeng...")
+            print("Dependencies installed. Restarting moodeng...")
             os.execl(sys.executable, sys.executable, *sys.argv)
         except Exception as e:
             print(f"❌ Error installing dependencies: {e}")
@@ -173,7 +174,7 @@ def main():
     
     # Create monitor with merged configuration
     monitor_config = {
-        'youtube_url': stream_url,  # Use the URL we already found
+        'source_url': stream_url,  # Use the URL we already found
     }
     
     if config:
@@ -196,7 +197,7 @@ def main():
     if args.debug:
         import logging
         logging.basicConfig(level=logging.DEBUG)
-        print("🐛 Debug mode enabled")
+        print("Debug mode enabled")
     
     # Create and start monitor
     print("🔧 Setting up detector...")
@@ -209,7 +210,7 @@ def main():
         print("👀 Watching the configured live source (Press Ctrl+C to stop)...")
         monitor.start()
     except KeyboardInterrupt:
-        print("\n👋 Stopping hippo monitor...")
+        print("\nStopping monitor...")
     except ConfigurationError as e:
         print(f"⚠️  Configuration error: {e}")
         if args.debug:

--- a/src/moodeng/config.py
+++ b/src/moodeng/config.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 import yt_dlp
 
+
 def get_latest_stream_url(channel_id: str = "ZoodioThailand") -> str:
     """Get the latest stream URL from a YouTube channel"""
     channel_id = channel_id.replace('@', '')
@@ -36,7 +37,7 @@ def get_latest_stream_url(channel_id: str = "ZoodioThailand") -> str:
         return None
 
 DEFAULT_CONFIG = {
-    "youtube_url": None,
+    "source_url": None,
     "target_label": "hippopotamus",
     "reference_name": None,
     "reference_images": None,
@@ -49,11 +50,19 @@ def get_config(custom_config: Dict[str, Any] = None) -> Dict[str, Any]:
     """Get configuration with custom overrides"""
     config = DEFAULT_CONFIG.copy()
     if custom_config:
+        if (
+            custom_config.get("source_url") is None
+            and custom_config.get("youtube_url") is not None
+        ):
+            custom_config = {
+                **custom_config,
+                "source_url": custom_config["youtube_url"],
+            }
         # Only update if we have non-None values
         config.update({k: v for k, v in custom_config.items() if v is not None})
-    
+
     # If no URL provided, get the latest
-    if not config.get("youtube_url"):
-        config["youtube_url"] = get_latest_stream_url()
-        
+    if not config.get("source_url"):
+        config["source_url"] = get_latest_stream_url()
+
     return config

--- a/src/moodeng/detector.py
+++ b/src/moodeng/detector.py
@@ -186,11 +186,12 @@ class HDRelayLiveFrameSource:
 
 class Monitor:
     """
-    Moo Deng monitor for hippo detection
+    Monitor live streams for detections from a configured target class.
     """
     def __init__(
         self,
         alerter: Optional[Alerter] = None,
+        source_url: Optional[str] = None,
         youtube_url: Optional[str] = None,
         target_label: str = "hippopotamus",
         reference_name: Optional[str] = None,
@@ -200,8 +201,9 @@ class Monitor:
         alert_cooldown: int = 300
     ):
         print("🎥 Loading detector...")
-        
+
         self.config = get_config({
+            "source_url": source_url,
             "youtube_url": youtube_url,
             "target_label": target_label,
             "reference_name": reference_name,
@@ -210,32 +212,32 @@ class Monitor:
             "min_confidence": min_confidence,
             "alert_cooldown": alert_cooldown
         })
-        
-        if not self.config.get("youtube_url"):
+
+        if not self.config.get("source_url"):
             raise ValueError("No source URL provided! This shouldn't happen - please report this bug on GitHub.")
-        
+
         self.alerter = alerter or LogAlerter()
         self.model = self._load_model()
         self.reference_matcher = self._load_reference_matcher()
         self.last_alert_time = 0
-        
+
     def _load_model(self):
         """Load and optimize model for detection"""
-        print("🦛 Loading Moo Deng detection model...")
+        print("Loading detection model...")
         try:
-            print("🔄 Loading OpenImages model...")
+            print("Loading OpenImages model...")
             model = YOLO('yolov8x-oiv7.pt')  # OpenImages V7 model
-            
+
             requested_label = self.config["target_label"]
             print(f"\n🔍 Confirming that {requested_label} is in the model...")
             self.target_class, self.target_model_label = self._find_target_class(
                 model,
                 requested_label,
             )
-            
+
             print(f"✨ Found {self.target_model_label} detection (class {self.target_class})")
             return model
-            
+
         except ModelError:
             raise
         except Exception as e:
@@ -274,7 +276,7 @@ class Monitor:
             f"Couldn't find a model class for '{requested_label}'.{suggestion_text}"
         )
 
-    def _get_stream_url(self, youtube_url: str) -> str:
+    def _get_stream_url(self, source_url: str) -> str:
         """Resolve a direct media URL from a supported page URL using yt-dlp."""
         ydl_opts = {
             'format': 'best',
@@ -282,7 +284,7 @@ class Monitor:
         }
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             try:
-                info = ydl.extract_info(youtube_url, download=False)
+                info = ydl.extract_info(source_url, download=False)
                 return info['url']
             except Exception as e:
                 print(f"\n❌ Stream error: {str(e)}")
@@ -428,7 +430,7 @@ class Monitor:
         """Monitor a direct video stream via OpenCV."""
         cap = cv2.VideoCapture(stream_url)
         try:
-            print(f"👀 Connected! Watching for {target_label} on {self.config['youtube_url']}")
+            print(f"👀 Connected! Watching for {target_label} on {self.config['source_url']}")
             if self.reference_matcher:
                 print(f"🧭 Reference matching is enabled for {subject_name}")
 
@@ -479,12 +481,12 @@ class Monitor:
 
     def start(self):
         """Start monitoring the stream"""
-        print(f"\n📡 Connecting to stream: {self.config['youtube_url']}")
+        print(f"\n📡 Connecting to stream: {self.config['source_url']}")
         target_label = self.target_model_label.title()
         subject_name = self.config.get("reference_name") or target_label
 
         try:
-            source = self._resolve_source(self.config["youtube_url"])
+            source = self._resolve_source(self.config["source_url"])
             if source["kind"] == "hdrelay_frames":
                 self._monitor_hdrelay_frames(source, target_label, subject_name)
             else:

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest import mock
+
+from moodeng.config import get_config
+from moodeng.detector import Monitor, _label_candidates, _normalize_remote_url
+
+
+class DetectorHelpersTest(unittest.TestCase):
+    def test_label_candidates_include_common_sea_lion_aliases(self):
+        candidates = _label_candidates("STELLAR SEA LIONS")
+        self.assertIn("stellar sea lions", candidates)
+        self.assertIn("steller sea lion", candidates)
+
+    def test_normalize_remote_url_adds_https_to_scheme_relative_urls(self):
+        self.assertEqual(
+            _normalize_remote_url("//img.hdrelay.com/"),
+            "https://img.hdrelay.com/",
+        )
+        self.assertEqual(
+            _normalize_remote_url("https://img.hdrelay.com/"),
+            "https://img.hdrelay.com/",
+        )
+
+    def test_get_config_accepts_legacy_youtube_url_alias(self):
+        config = get_config({"youtube_url": "https://example.com/live"})
+        self.assertEqual(config["source_url"], "https://example.com/live")
+
+    def test_resolve_source_keeps_direct_stream_urls(self):
+        monitor = Monitor.__new__(Monitor)
+        resolved = monitor._resolve_source("rtsp://example.com/live")
+        self.assertEqual(
+            resolved,
+            {"kind": "video_capture", "capture_url": "rtsp://example.com/live"},
+        )
+
+    def test_resolve_source_uses_hdrelay_resolver_for_pier39(self):
+        monitor = Monitor.__new__(Monitor)
+        expected = {"kind": "hdrelay_frames", "camera_id": "cid"}
+        with mock.patch.object(
+            monitor,
+            "_resolve_hdrelay_page_source",
+            return_value=expected,
+        ) as resolve_hdrelay:
+            resolved = monitor._resolve_source("https://www.pier39.com/sealions/")
+
+        resolve_hdrelay.assert_called_once_with("https://www.pier39.com/sealions/")
+        self.assertEqual(resolved, expected)
+
+    def test_resolve_source_falls_back_to_yt_dlp_for_supported_pages(self):
+        monitor = Monitor.__new__(Monitor)
+        with mock.patch.object(
+            monitor,
+            "_get_stream_url",
+            return_value="https://cdn.example.com/stream.m3u8",
+        ) as get_stream_url:
+            resolved = monitor._resolve_source("https://example.com/watch")
+
+        get_stream_url.assert_called_once_with("https://example.com/watch")
+        self.assertEqual(
+            resolved,
+            {
+                "kind": "video_capture",
+                "capture_url": "https://cdn.example.com/stream.m3u8",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

This PR is a follow-up to the merged PIER 39 live-source work.

It cleans up the remaining product and API inconsistencies without changing the core HDRelay integration.

It includes:

- prefer `source_url` across the Python API and docs
- keep legacy `youtube_url` support as a compatibility alias
- remove the most obvious stale hippo/Moo Deng-specific user-facing strings
- clarify in the README that Chonkers reference image paths are examples only and are not committed assets
- add a minimal automated test file for config aliasing, label aliases, remote URL normalization, and source resolution

## Why

The first PR landed the functional PIER 39 support, but it still had leftovers from the earlier Moo Deng-specific version of the tool.

Those leftovers made the public surface inconsistent:

- docs used a broader model than some runtime strings
- the Python API still centered `youtube_url` even though the code supports generic live sources
- the repo still had no real automated test coverage for the new helper and routing logic

## User impact

Users can now rely on `source_url` as the primary Python API field, while existing `youtube_url` callers keep working.

The README and CLI wording are more consistent with the current behavior, and the repo now has a small real test target.

## Validation

I ran the following checks locally:

- `python3 -m compileall src/moodeng tests`
- `PYTHONPATH=src .venv/bin/python -m unittest discover -s tests`
- `PYTHONPATH=src .venv/bin/python -m moodeng.cli --help`
- `git diff --check`
- Pier 39 live-source smoke test:
  - resolved `https://www.pier39.com/sealions/` to camera `CID_UROS0000008D`
  - fetched a live `6526x1576` frame through the HDRelay path
